### PR TITLE
Add cache clear command to Quick Demo section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Quick Demo
 ==========
 
     git clone https://github.com/pantheon-systems/terminus.git $HOME/.drush/terminus
+    drush cc drush
     drush pantheon-auth
     drush pantheon-sites
     drush pantheon-aliases

--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -452,7 +452,7 @@ function drush_terminus_pantheon_site_get_backup($site_uuid = FALSE, $environmen
  * Make a backup. Uses more generic backup api.
  */
 function drush_terminus_pantheon_site_make_backup($site_uuid, $environment) {
-  $data = terminus_session_data();
+  $data = terminus_bootstrap();
   if (!$data) {
     drush_log('You are not authenticated', 'failed');
     return FALSE;


### PR DESCRIPTION
It might be useful to remind people of clearing the drush cache if the pantheon commands don't appear.
