### PR TITLE
Add environment as an argument for pantheon-site-backups.

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -150,6 +150,7 @@ function terminus_drush_command() {
     'description' => "List site backups (and exports).",
     'arguments' => array(
       'site' => 'UUID of the site you want to get backups for.',
+      'environment' => 'The environment (e.g. "live") you want to back up.',
     ),
     'aliases' => array('psite-backups'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
@@ -393,6 +394,10 @@ function drush_terminus_pantheon_site_backups($site_uuid = FALSE, $environment =
 
   if (!$site_uuid) {
     drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
+  }
+  if (!$environment) {
+    drush_log('You must supply a specific environment', 'failed');
     return FALSE;
   }
 


### PR DESCRIPTION
The callback for pantheon-site-backups could take environment but it doesn't require it in the drush command and it wasn't checked for in the function which creates this error when called without the environment: 

Bens-MacBook-Pro:terminus ben$ drush pantheon-site-backups $SITE-ID
Request failed: 404 Not found.                                                                               [failed]
Invalid argument supplied for foreach() terminus.drush.inc:404                                               [warning]
 Type  Date  Element  Bucket  Size
