### PR TITLE
Tunnel support

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -365,13 +365,9 @@ function drush_terminus_pantheon_site_delete($site_uuid = FALSE) {
   }
   extract($session_data);
 
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    $prompt = TRUE;
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
+  if (!$site_uuid = terminus_site_input($site_uuid, TRUE, TRUE)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
   $confirm = drush_confirm("Are you sure you want to delete?");
@@ -396,13 +392,9 @@ function drush_terminus_pantheon_hostname_add($site_uuid = FALSE, $environment =
   }
   extract($session_data);
 
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    $prompt = TRUE;
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
+  if (!$site_uuid = terminus_site_input($site_uuid, TRUE, TRUE)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
   if (!$environment) {
@@ -478,12 +470,9 @@ function drush_terminus_pantheon_site_backups($site_uuid = FALSE, $environment =
   }
   extract($session_data);
 
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
+  if (!$site_uuid = terminus_site_input($site_uuid, TRUE, TRUE)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
   if (!$environment) {
@@ -525,12 +514,9 @@ function drush_terminus_pantheon_site_get_backup($site_uuid = FALSE, $environmen
   }
   extract($session_data);
 
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
+  if (!$site_uuid = terminus_site_input($site_uuid, TRUE, TRUE)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
   if (!$environment) {
@@ -563,12 +549,9 @@ function drush_terminus_pantheon_site_make_backup($site_uuid = FALSE, $environme
   }
   extract($session_data);
 
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
+  if (!$site_uuid = terminus_site_input($site_uuid, TRUE, TRUE)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
   if (!$environment) {
@@ -593,25 +576,11 @@ function drush_terminus_pantheon_site_download_backup($site_uuid = FALSE, $envir
   }
   extract($session_data);
 
-  // If $site_uuid is not a uuid, lookup by name.
-  if (!terminus_validate_uuid($site_uuid)) {
-    $site_uuid = terminus_get_site_uuid_by_name($site_uuid);
+  if (!$site_uuid = terminus_site_input($site_uuid)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
-  // Retrieve the latest bucket
-  if ($bucket == 'latest') {
-    $bucket = terminus_latest_bucket($site_uuid, $environment, $element);
-  }
-
-  $prompt = FALSE;
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    $prompt = TRUE;
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
-  }
   if (!$environment) {
     $environment = terminus_session_select_data('environment', $site_uuid);
     if (!$environment) {
@@ -625,6 +594,11 @@ function drush_terminus_pantheon_site_download_backup($site_uuid = FALSE, $envir
       drush_log('You must supply an element', 'failed');
       return FALSE;
     }
+  }
+
+  // Retrieve the latest bucket
+  if ($bucket == 'latest') {
+    $bucket = terminus_latest_bucket($site_uuid, $environment, $element);
   }
   if (!$bucket) {
     $bucket = terminus_session_select_data('bucket', $site_uuid, $environment, $element);
@@ -644,11 +618,6 @@ function drush_terminus_pantheon_site_download_backup($site_uuid = FALSE, $envir
   $result = terminus_api_backup_download_url($site_uuid, $environment, $bucket, $element);
   $data = json_decode($result['json']);
   $filename = strstr(basename($data->url), '?', '_');
-
-  // Display command if they build this from the command prompt.
-  if ($prompt) {
-    drush_log("Cmd: drush psite-dl-backup " . $site_uuid . " " . $environment . " " . $bucket . " " . $element . " \"" . $destination . "\"", 'ok');
-  }
 
   drush_log("Downloading " . $filename . "...");
 
@@ -676,25 +645,16 @@ function drush_terminus_pantheon_site_load_backup($site_uuid = FALSE, $environme
   extract($session_data);
   $element = 'database';
 
-  // If $site_uuid is not a uuid, lookup by name.
-  if (strlen($site_uuid) != 36) {
-    $site_uuid = terminus_get_site_uuid_by_name($site_uuid);
+  if (!$site_uuid = terminus_site_input($site_uuid)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
   }
 
   // Retrieve the latest bucket
-  if ($bucket == 'latest') {
+  if ($bucket == 'latest' || (!$bucket && $site_uuid && $environment)) {
     $bucket = terminus_latest_bucket($site_uuid, $environment, $element);
   }
 
-  $prompt = FALSE;
-  if (!$site_uuid) {
-    $site_uuid = terminus_session_select_data('site_uuid');
-    $prompt = TRUE;
-    if (!$site_uuid) {
-      drush_log('You must supply a site UUID', 'failed');
-      return FALSE;
-    }
-  }
   if (!$environment) {
     $environment = terminus_session_select_data('environment');
     if (!$environment) {
@@ -702,7 +662,7 @@ function drush_terminus_pantheon_site_load_backup($site_uuid = FALSE, $environme
       return FALSE;
     }
   }
-  if ($prompt && !$bucket) {
+  if (!$bucket) {
     $bucket = terminus_session_select_data('bucket', $site_uuid, $environment, $element);
     if (!$bucket) {
       drush_log('You must supply a bucket', 'failed');
@@ -1274,6 +1234,22 @@ function terminus_latest_bucket($site_uuid, $environment, $element = NULL) {
   }
   krsort($buckets);
   return reset($buckets);
+}
+
+/**
+ * Helper function to handle site uuid input.
+ */
+function terminus_site_input($site_input, $prompt = TRUE, $uuid_only = FALSE) {
+  if (!$site_input && $prompt) {
+    $site_input = terminus_session_select_data('site_uuid');
+  }
+  if (terminus_validate_uuid($site_input)) {
+    return $site_input;
+  }
+  if (empty($site_input) || $uuid_only) {
+    return FALSE;
+  }
+  return terminus_get_site_uuid_by_name($site_input);
 }
 
 /**

--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -196,11 +196,22 @@ function terminus_drush_command() {
   $items['pantheon-site-load-backup'] = array(
     'description' => "Load db with a backup file from a specific site.",
     'arguments' => array(
-      'site' => 'UUID of the site you want to get backups for.',
-      'environment' => 'The environment (e.g. "live") you want to back up.',
+      'site' => 'UUID or name of the site you want to get backups for.',
+      'environment' => 'The environment (e.g. "live") you want to use a backup from.',
       'bucket' => 'Bucket for the backup. Use "latest" for the most recent.',
     ),
     'aliases' => array('psite-load-backup'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
+  );
+
+  $items['pantheon-site-connection-mode'] = array(
+    'description' => "Set or retrieve the connection mode of a specific site/environment.",
+    'arguments' => array(
+      'site' => 'UUID or name of the site.',
+      'environment' => 'The environment (e.g. "live") you would like to target.',
+      'mode' => 'Connection mode like to set. (e.g. "sftp" or "git") Leave blank to retrieve the current mode.',
+    ),
+    'aliases' => array('psite-cmode'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
   );
 
@@ -656,7 +667,7 @@ function drush_terminus_pantheon_site_load_backup($site_uuid = FALSE, $environme
   }
 
   if (!$environment) {
-    $environment = terminus_session_select_data('environment');
+    $environment = terminus_session_select_data('environment', $site_uuid);
     if (!$environment) {
       drush_log('You must supply an environment', 'failed');
       return FALSE;
@@ -699,6 +710,50 @@ function drush_terminus_pantheon_site_load_backup($site_uuid = FALSE, $environme
   drush_delete_dir($path);
 
   return TRUE;
+}
+
+/**
+ * Set or retrieve the connection mode for a site/environment.
+ */
+function drush_terminus_pantheon_site_connection_mode($site_uuid = FALSE, $environment = FALSE, $cmode = FALSE) {
+  $session_data = terminus_bootstrap();
+  if ($session_data === FALSE) {
+    return FALSE;
+  }
+  extract($session_data);
+
+  // Only prompt for $cmode if the command is run without a site or environment
+  $prompt_cmode = !$site_uuid || !$environment;
+
+  if (!$site_uuid = terminus_site_input($site_uuid)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
+  }
+
+  if (!$environment) {
+    $environment = terminus_session_select_data('environment', $site_uuid);
+    if (!$environment) {
+      drush_log('You must supply an environment', 'failed');
+      return FALSE;
+    }
+  }
+
+  if ($prompt_cmode && !$cmode) {
+    $cmode = terminus_session_select_data('cmode', $site_uuid);
+  }
+
+  if (!$cmode) {
+    $result = terminus_api_site_environment_onserverdev_get($site_uuid, $environment);
+    $data = json_decode($result['json']);
+    $mode = $data->enabled? 'SFTP' : 'Git';
+    drush_log("Connection mode: " . $mode, 'ok');
+    return TRUE;
+  }
+
+  $onserverdevstatus = $cmode == 'sftp' ? TRUE : FALSE;
+  terminus_api_site_environment_onserverdev_set($site_uuid, $environment, $onserverdevstatus);
+
+  drush_log('Connection mode set to: ' . $cmode, 'ok');
 }
 
 /**
@@ -1190,6 +1245,11 @@ function terminus_session_select_data($key, $site_uuid = NULL, $environment = NU
       if ($val !== FALSE) {
         return $buckets[$val];
       }
+      break;
+
+    case 'cmode':
+      $choices = array(0 => 'Retrieve connection mode', 'sftp' => 'SFTP', 'git' => 'Git');
+      return drush_choice($choices, 'Connection mode');
       break;
 
     case 'destination':

--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -24,6 +24,7 @@ function terminus_bootstrap($validate = TRUE) {
   include_once('terminus.backup.api.inc');
   include_once('terminus.site.api.inc');
   include_once('terminus.user.api.inc');
+  include_once('terminus.tunnel.inc');
   $session_data = terminus_session_data();
   // DRY session validation.
   if ($validate) {
@@ -79,7 +80,6 @@ function terminus_drush_command() {
     'aliases' => array('pauth'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
   );
-
 
   // The 'pantheon-sitelist' command
   $items['pantheon-sites'] = array(
@@ -213,6 +213,68 @@ function terminus_drush_command() {
     ),
     'aliases' => array('psite-cmode'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
+  );
+
+  /**
+   * Tunnel Functions.
+   */
+  $items['pantheon-site-tunnels'] = array(
+    'description' => "Get a list of open tunnels.",
+    'aliases' => array('psite-tunnels'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
+  );
+
+  $items['pantheon-site-tunnel'] = array(
+    'description' => "Opens a tunnel to a specific site/environment/service.",
+    'arguments' => array(
+      'site' => 'UUID or name of the site.',
+      'environment' => 'The target environment (e.g. "live").',
+      'service' => 'The service (e.g. "db" or "redis") to open a tunnel for. This defaults to "db".',
+      'port' => 'Local port to connect to.'
+    ),
+    'aliases' => array('psite-tunnel'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
+  );
+
+  $items['pantheon-site-tunnel-close'] = array(
+    'description' => "Closes the tunnel to a specific site/environment/service.",
+    'arguments' => array(
+      'site' => 'UUID or name of the site. If left empty, all tunnels will be closed.',
+      'environment' => 'The target environment (e.g. "live"). If left empty, all site tunnels will be closed.',
+      'service' => 'The service (e.g. "mysql" or "redis") to open a tunnel for. If empty, all site/environment tunnels will be closed.'
+    ),
+    'aliases' => array('psite-tclose'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH, // No bootstrap at all.
+  );
+
+  $items['pantheon-site-sql-dump'] = array(
+    'callback' => 'drush_sql_dump_execute',
+    'description' => 'Exports the Drupal DB as SQL using mysqldump or equivalent.',
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'examples' => array(
+      'drush sql-dump --result-file=../18.sql' => 'Save SQL dump to the directory above Drupal root.',
+      'drush sql-dump --skip-tables-key=common' => 'Skip standard tables. @see example.drushrc.php',
+    ),
+    'options' => array(
+      'result-file' => array(
+        'description' => 'Save to a file. The file should be relative to Drupal root. If --result-file is provided with no value, then date based filename will be created under ~/drush-backups directory.',
+        'example-value' => '/path/to/file',
+        'value' => 'optional',
+      ),
+      'skip-tables-key' => 'A key in the $skip_tables array. @see example.drushrc.php. Optional.',
+      'structure-tables-key' => 'A key in the $structure_tables array. @see example.drushrc.php. Optional.',
+      'tables-key' => 'A key in the $tables array. Optional.',
+      'skip-tables-list' => 'A comma-separated list of tables to exclude completely. Optional.',
+      'structure-tables-list' => 'A comma-separated list of tables to include for structure, but not data. Optional.',
+      'tables-list' => 'A comma-separated list of tables to transfer. Optional.',
+      'ordered-dump' => 'Use this option to output ordered INSERT statements in the sql-dump.Useful when backups are managed in a Version Control System. Optional.',
+      'create-db' => array('hidden' => TRUE, 'description' => 'Omit DROP TABLE statements. Postgres and Oracle only.  Used by sql-sync, since including the DROP TABLE statements interfere with the import when the database is created.'),
+      'data-only' => 'Dump data without statements to create any of the schema.',
+      'ordered-dump' => 'Order by primary key and add line breaks for efficient diff in revision control. Also, faster rsync. Slows down the dump. Mysql only.',
+      'gzip' => 'Compress the dump using the gzip program which must be in your $PATH.',
+    ),
+    'aliases' => array('psite-sql-dump'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
   );
 
   /**
@@ -756,6 +818,67 @@ function drush_terminus_pantheon_site_connection_mode($site_uuid = FALSE, $envir
 
   $mode = $onserverdevstatus ? 'SFTP' : 'Git';
   drush_log('Connection mode set to: ' . $mode, 'ok');
+}
+
+/**
+ * Displays a list of open tunnels
+ */
+function drush_terminus_pantheon_site_tunnels() {
+  $session_data = terminus_bootstrap();
+  if ($session_data === FALSE) {
+    return FALSE;
+  }
+  extract($session_data);
+  $tunnels = terminus_tunnel_get_all();
+  terminus_tunnel_print_info_table($tunnels['data']);
+}
+
+/**
+ * Opens a tunnel for a specific site/environment/service
+ */
+function drush_terminus_pantheon_site_tunnel($site_uuid = FALSE, $environment = FALSE, $service = 'mysql', $port = NULL, $print_info = TRUE) {
+  $session_data = terminus_bootstrap();
+  if ($session_data === FALSE) {
+    return FALSE;
+  }
+  extract($session_data);
+
+  if (!$site_uuid = terminus_site_input($site_uuid)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
+  }
+
+  if (!$environment) {
+    $environment = terminus_session_select_data('environment', $site_uuid);
+    if (!$environment) {
+      drush_log('You must supply an environment', 'failed');
+      return FALSE;
+    }
+  }
+
+  $types = array(
+    'mysql' => 'dbserver',
+    'redis' => 'cacheserver'
+  );
+
+  if (!isset($types[$service])) {
+    return drush_set_error('TERMINUS_TUNNEL_ERROR', dt('Invlalid service: @service. Try "mysql" or "redis".', array('@service' => $service)));
+  }
+
+  return terminus_tunnel_open($site_uuid, $environment, $types[$service], $port, $print_info);
+}
+
+/**
+ * Close tunnels
+ */
+function drush_terminus_pantheon_site_tunnel_close($pid = NULL) {
+  $session_data = terminus_bootstrap();
+  if ($session_data === FALSE) {
+    return FALSE;
+  }
+  extract($session_data);
+
+  terminus_tunnel_close($pid);
 }
 
 /**
@@ -1339,6 +1462,39 @@ function terminus_get_site_uuid_by_name($site_name) {
     }
   }
   return FALSE;
+}
+
+/**
+ * Helper function to leverage cache and static sites array.
+ */
+function terminus_user_site_list($reset = FALSE) {
+  static $asites;
+  if (isset($asites) && !$reset) {
+    return $asites;
+  }
+
+  $session_data = terminus_bootstrap();
+  if ($session_data === FALSE) {
+    return FALSE;
+  }
+  extract($session_data);
+
+  $cid = 'terminus-sites';
+  if ($reset || !$cache = drush_cache_get($cid, 'pantheon')) {
+    drush_log('Loading site data from Pantheon.', 'notice');
+    $result = terminus_api_user_site_list($user_uuid);
+    if ($result === FALSE) {
+      return FALSE;
+    }
+    $asites = json_decode($result['json']);
+  }
+  else {
+    drush_log('Loaded site data from cache.', 'notice');
+    $asites = $cache->data;
+  }
+
+  drush_cache_set($cid, $asites, 'pantheon');
+  return $asites;
 }
 
 /**

--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -750,10 +750,12 @@ function drush_terminus_pantheon_site_connection_mode($site_uuid = FALSE, $envir
     return TRUE;
   }
 
+  $cmode = strtolower($cmode);
   $onserverdevstatus = $cmode == 'sftp' ? TRUE : FALSE;
   terminus_api_site_environment_onserverdev_set($site_uuid, $environment, $onserverdevstatus);
 
-  drush_log('Connection mode set to: ' . $cmode, 'ok');
+  $mode = $onserverdevstatus ? 'SFTP' : 'Git';
+  drush_log('Connection mode set to: ' . $mode, 'ok');
 }
 
 /**

--- a/terminus.tunnel.inc
+++ b/terminus.tunnel.inc
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * @file
+ * Terminus tunnel support.
+ */
+
+/**
+ * Returns an array of open tunnels.
+ */
+function terminus_tunnel_get_all() {
+  $tunnels = array('data' => array(), 'ports' => array());
+  if (drush_shell_exec('ps -fU $USER |grep "ssh -[f]" | awk \'{print $2, $5, $12, $15}\'')) {
+    $sites = terminus_user_site_list();
+    $lines = drush_shell_exec_output();
+    $keys = array('raw', 'pid', 't1', 't2', 'port', 'host', 'rport', 'ruser', 'rhost', 'type', 'environment', 'site_uuid');
+    // tunnels are keyed by port, ports are keyed by env.site for mapping.
+    foreach ($lines as $line) {
+      $matches = array();
+      if (preg_match('/([0-9]{1,8}) ([0-9]{1,2}:[0-9]{2})(PM|AM) ([0-9]{1,7}):(localhost):([0-9]{1,7}) ([A-z0-9_]{3,16}\.[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})@(([A-z0-9_]{3,16})\.([A-z0-9_]{3,16})\.([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\.drush.in)/', $line, $matches)) {
+        $tunnel = array_combine($keys, $matches);
+        $tunnel['site'] = isset($sites[$tunnel['site_uuid']]) ? $sites[$tunnel['site_uuid']]['information']['name'] : $tunnel['site_uuid'];
+        $tunnels['data'][$tunnel['port']] = $tunnel;
+        $tunnels['ports'][$tunnel['rhost']] = $tunnel['port'];
+      }
+    }
+  }
+  return $tunnels;
+}
+
+/**
+ * Opens a tunnel if one is not already open.
+ */
+function terminus_tunnel_open($site_uuid, $environment, $type = 'dbserver', $port = NULL, $print_info = TRUE) {
+  // If tunnel exists, display connection info
+  $result = terminus_api_site_environment_bindings($site_uuid, $environment, $type);
+  $bindings = json_decode($result['json']);
+  $binding = reset($bindings);
+
+  if (empty($binding)) {
+    return drush_set_error('TERMINUS_TUNNEL_ERROR', dt('Could not find binding for: @type', array('@type' => $type)));
+  }
+
+  $tunnel = NULL;
+  $port = isset($port) ? $port : $binding->port;
+  $rhost = $type . '.' . $environment . '.' . $site_uuid . '.drush.in';
+  if ($tunnel = terminus_tunnel_get($port)) {
+    if ($rhost == $tunnel['rhost']) {
+
+      drush_log(dt('Tunnel already open to @rhost:@rport.', array('@rhost' => $tunnel['rhost'], '@rport' => $tunnel['rport'])), 'ok');
+    }
+    else {
+      terminus_tunnel_print_info_table(array($tunnel));
+      return drush_set_error('TERMINUS_TUNNEL_ERROR', dt('Port @port is already in use with a different service or host.', array('@port' => $port)));
+    }
+  }
+  else {
+
+    $cmd = "ssh -f -N -L {$port}:localhost:{$binding->port} -p 2222 {$environment}.{$site_uuid}@{$rhost}";
+    $status = drush_shell_proc_open($cmd);
+    if ($status != 0) {
+      return drush_set_error('TERMINUS_SSH_ERROR', dt('An error @code occurred while opening a tunnel with the command `@command`', array('@command' => $cmd, '@code' => $status)));
+    }
+
+    if ($tunnel = terminus_tunnel_get($site_uuid, $environment, $type)) {
+      drush_log(dt('Tunnel opened to @rhost:@rport.', array('@rhost' => $tunnel['rhost'], '@rport' => $tunnel['rport'])), 'ok');
+    }
+    else {
+      return drush_set_error('TERMINUS_TUNNEL_ERROR', dt('Unable to verify tunnel was created.'));
+    }
+  }
+
+  $tunnel['binding'] = $binding;
+  if ($print_info) {
+    terminus_tunnel_print_info_table(array($tunnel));
+
+    // Display type specific tunnel info
+    $func = 'terminus_tunnel_info_' . $type;
+    if (isset($tunnel) && function_exists($func)) {
+      $func($tunnel, $binding);
+    }
+  }
+
+  return $tunnel;
+}
+
+/**
+ * Kill tunnel(s)
+ */
+function terminus_tunnel_close($pid = NULL) {
+  $msg = NULL;
+  if (isset($pid)) {
+    $cmd = 'kill ' . $pid;
+    $msg = dt('Tunnel closed for pid: @pid', array('@pid' => $pid));
+  }
+  else {
+    $cmd = "ps -fU \$USER | grep 'ssh -[f]' | awk '{print \$2}' | xargs kill";
+    $msg = dt('All tunnels closed');
+  }
+  drush_shell_exec($cmd);
+  drush_log($msg, 'ok');
+}
+
+/**
+ * Helper function to retrieve an open tunnel.
+ */
+function terminus_tunnel_get($site_uuid_or_port, $environment = NULL, $type = NULL) {
+  $tunnels = terminus_tunnel_get_all();
+  $port = NULL;
+  if (is_numeric($site_uuid_or_port)) {
+    $port = $site_uuid_or_port;
+  }
+  else {
+    $tkey = _terminus_tunnel_key($site_uuid_or_port, $environment, $type);
+    $port = $tunnels['ports'][$tkey];
+  }
+  if (isset($tunnels['data'][$port])) {
+    return $tunnels['data'][$port];
+  }
+  return FALSE;
+}
+
+/**
+ * Returns a Tunnel array to be used in an info table.
+ */
+function terminus_tunnel_print_info_table($tunnels) {
+  $rows = array();
+  $rows[] = array('PID', 'Since', 'Site', 'Env', 'Type', 'Local', 'Remote');
+  foreach ($tunnels as $tunnel) {
+   $rows[] = array( $tunnel['pid'], $tunnel['t1'] . $tunnel['t2'], $tunnel['site'], $tunnel['environment'], $tunnel['type'],  $tunnel['port'], $tunnel['rport']);
+  }
+  drush_print('');
+  drush_print_table($rows, TRUE);
+  drush_print('');
+}
+
+/**
+ * Prints connection info for a dbserver tunnel.
+ */
+function terminus_tunnel_info_dbserver($tunnel, $binding = NULL) {
+  $rows = array();
+  $rows[] = array('Host', 'Port', 'Username', 'Password', 'Database');
+  $rows[] = array($tunnel['host'], $tunnel['port'], $binding->username, $binding->password, $binding->database);
+  drush_print_table($rows, TRUE);
+  drush_print('');
+  drush_print(' Command line');
+  drush_print(dt('  mysql -u @username -p@password -h @host -P @port @database',
+    array('@username' => $binding->username, '@password' => $binding->password, '@host' => $tunnel['host'], '@port' => $tunnel['port'], '@database' => $binding->database))
+  );
+  drush_print('');
+}
+
+/**
+ * Helper function to build a key used to identify open tunnels.
+ */
+function _terminus_tunnel_key($site_uuid, $environment, $type) {
+  return $type . '.' . $environment . '.' . $site_uuid . '.drush.in';
+}


### PR DESCRIPTION
This is a working start for tunnel support.  See #5 for more detail.
- allows user to create an ssh tunnel by sitename and environment.
- tunnels will be re-used when a tunnel is opened to the same site/env/binding/port
- error will be displayed when a tunnel is opened to a different service that has a port already opened
- ports can be closed all at once, or one at a time
- local connection info will be displayed when opening a tunnel (mysql only currently)

```
# Create tunnel to mysql
drush psite-tunnel mysite dev
# -or-
drush psite-tunnel mysite dev mysql

# Create tunnel to redis
drush psite-tunnel mysite dev redis

# Create tunnel to mysql with a local port of 4000
drush psite-tunnel mysite dev mysql 4000

# List tunnels
drush psite-tunnels

# Close all tunnels
drush psite-tclose

# Close tunnel for pid 1234  (pid is displayed when listing tunnels)
drush psite-tclose 1234
```

I'm wondering if we should use "mysql" and "redis" for the user vs the binding style of naming of "db" and "cache".  I believe Pantheon docs, helpdesk, etc uses mysql/redis so I thought that would be more meaningful to the user. I have gone back and forth on that though.
