### PR TITLE
sshfs support: psite-mount

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -292,7 +292,7 @@ function terminus_drush_command() {
     'arguments' => array(
       'site' => 'UUID or name of the site. If left empty, all tunnels will be closed.',
       'environment' => 'The target environment (e.g. "live"). If left empty, all site tunnels will be closed.',
-      'destination' => 'Where would you like the backup?'
+      'destination' => 'Where would you to mount the file system?'
     ),
     'aliases' => array('psite-mount'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,

--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -287,6 +287,17 @@ function terminus_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
   );
 
+  $items['pantheon-site-mount'] = array(
+    'description' => "Mounts an environment file system to a local directory.",
+    'arguments' => array(
+      'site' => 'UUID or name of the site. If left empty, all tunnels will be closed.',
+      'environment' => 'The target environment (e.g. "live"). If left empty, all site tunnels will be closed.',
+      'destination' => 'Where would you like the backup?'
+    ),
+    'aliases' => array('psite-mount'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+  );
+
   /**
    * Workflow.
    */
@@ -1093,6 +1104,62 @@ function drush_terminus_pantheon_site_tunnel_close($pid = NULL) {
 }
 
 /**
+ * Mounts the appserver for a specific environment.
+ */
+function drush_terminus_pantheon_site_mount($site_uuid = FALSE, $environment = FALSE, $destination = FALSE) {
+  $session_data = terminus_bootstrap();
+  if ($session_data === FALSE) {
+    return FALSE;
+  }
+  extract($session_data);
+
+  if (!$site_uuid = terminus_site_input($site_uuid)) {
+    drush_log('You must supply a site UUID', 'failed');
+    return FALSE;
+  }
+
+  if (!$environment) {
+    $environment = terminus_session_select_data('environment', $site_uuid);
+    if (!$environment) {
+      drush_log('You must supply an environment', 'failed');
+      return FALSE;
+    }
+  }
+
+  if (!$destination) {
+    $destination = terminus_session_select_data('destination', NULL, NULL, NULL, 'Select a mount destination:', './' . $environment);
+    if (!$destination) {
+      drush_log('You must supply a mount destination', 'failed');
+      return FALSE;
+    }
+  }
+
+  if (!is_dir($destination)) {
+    drush_print(dt("The directory !destination does not exist.", array('!destination' => $destination)));
+    if (drush_confirm(dt('Would you like to create it?'))) {
+      drush_mkdir($destination, TRUE);
+    }
+    if (!is_dir($destination)) {
+      return drush_set_error('DRUSH_PSITE_MOUNT_DESTINATION', dt('Unable to create destination directory !destination.', array('!destination' => $destination)));
+    }
+  }
+
+  $user = $environment . '.' . $site_uuid;
+  $host = 'appserver.' . $environment . '.' . $site_uuid . '.drush.in';
+  $cmd = "sshfs -p 2222 {$user}@{$host}:./ {$destination}";
+
+  drush_shell_exec($cmd);
+  $output = drush_shell_exec_output();
+
+  if (empty($output)) {
+    drush_log(dt('Mount successful. To unmount, run: umount !destination', array('!destination' => $destination)), 'ok');
+  }
+  else {
+    return drush_set_error('DRUSH_PSITE_MOUNT', dt('Unable to mount: !output', array('!output' => implode("\n", $output))));
+  }
+}
+
+/**
  * Update drush aliases file.
  */
 function drush_terminus_pantheon_aliases() {
@@ -1501,7 +1568,7 @@ function terminus_parse_drupal_headers($result, $target_header='Set-Cookie') {
  * @param $key string Required data name. i.e. site_uuid, environment, etc..
  * @return string input data
  */
-function terminus_session_select_data($key, $site_uuid = NULL, $environment = NULL, $element = NULL) {
+function terminus_session_select_data($key, $site_uuid = NULL, $environment = NULL, $element = NULL, $prompt_text = NULL, $default = NULL) {
   $session_data = terminus_bootstrap();
   if ($session_data === FALSE) {
     return FALSE;
@@ -1579,7 +1646,7 @@ function terminus_session_select_data($key, $site_uuid = NULL, $environment = NU
       break;
 
     case 'destination':
-      $val = drush_prompt('Select a destination', $default = './');
+      $val = drush_prompt(isset($prompt_text) ? $prompt_text : 'Select a destination', isset($default) ? $default : './');
       if ($val !== FALSE) {
         return $val;
       }


### PR DESCRIPTION
This adds sshfs support to mount the appserver file system by site name and environment. Tests have been done on Mac OSX with http://osxfuse.github.io/

It takes 3 arguments: site, environment, destination.

The destination is the path you would like to mount the remote file system to.

If the destination directory does not exist locally, sshfs cannot mount. Drush will prompt for it to be created if it does not exist.

By the time it gets to the part where it actually runs the sshfs command, it will most likely complete. The potential errors are if the destination already has something mounted to it, or the sshfs command doesn't exist.  In this case, a drush error will report the problem.

Command with all params and existing target directory:

```
$ drush psite-mount mysite dev ./some_dir
```

With prompts and no existing target directory

```
$ drush psite-mount
Select a site.
 [0]  :  Cancel                                                                 
 [1]  :  mysite               enterprise  14a61510-1e81-11e3-8224-0800200c9a66 
1

Select an environment.
 [0]   :  Cancel      
 [1]   :  dev         
 [2]   :  live        
 [3]   :  test        

1
Select a mount destination: [./dev]: 
The directory ./dev does not exist.
Would you like to create it? (y/n): y
Mount successful. To unmount, run: umount ./dev                                          [ok]

$ ls dev/
cache       drushrc.php htpasswd    mime.types  php53.ini
certs       files       includes    nginx.conf  run
chef.stamp  fusedav.conf    logs        php-fpm.conf    tmp
code        fusedav_version metadata.json   php.ini
```
