### PR TITLE
Fix: 5b10c4c introduced 'Cannot use object of type stdClass as array'

### DIFF
--- a/terminus.tunnel.inc
+++ b/terminus.tunnel.inc
@@ -11,7 +11,7 @@
 function terminus_tunnel_get_all() {
   $tunnels = array('data' => array(), 'ports' => array());
   if (drush_shell_exec('ps -fU $USER |grep "ssh -[f]" | awk \'{print $2, $5, $12, $15}\'')) {
-    $sites = json_decode(terminus_user_site_list());
+    $sites = json_decode(terminus_user_site_list(), TRUE);
     $lines = drush_shell_exec_output();
     $keys = array('raw', 'pid', 't1', 't2', 'port', 'host', 'rport', 'ruser', 'rhost', 'type', 'environment', 'site_uuid');
     // tunnels are keyed by port, ports are keyed by env.site for mapping.


### PR DESCRIPTION
After pulling 5b10c4c I get a new error

[bwood@ucbmbp private]$ drush psite-tunnel parking dev
Drush command terminated abnormally due to an unrecoverable error.                                         [error]
Error: Cannot use object of type stdClass as array in /Users/bwood/.drush/terminus/terminus.tunnel.inc,
line 22

This fixes that error.
