### PR TITLE
Need to sort array values, not keys, to find latest bucket

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -2700,7 +2700,7 @@ function terminus_latest_bucket($site_uuid, $environment, $element = NULL) {
     }
     $buckets[$a->filename] = $parts[0] .'_'. $parts[1];
   }
-  krsort($buckets);
+  arsort($buckets);
   return reset($buckets);
 }
 


### PR DESCRIPTION
Noticed that after creating a site on Pantheon and then making a backup the "import" bucket was still coming through as the "latest" bucket. This happens because sorting by the buckets keys is just sorting by what seems to be filename vs the TIMESTAMP_BUCKETTYPE array value which seems to be what we want to be sorting by.

Anyway...
