### PR TITLE
Api cleanup & uuid request fix

### DIFF
--- a/terminus.site.api.inc
+++ b/terminus.site.api.inc
@@ -11,6 +11,7 @@
 function terminus_api_site_info($site_uuid) {
   $realm = 'site';
   $uuid = $site_uuid;
+  $path = '';
   $method = 'GET';
 
   return terminus_request($realm, $uuid, $path, $method);

--- a/terminus.user.api.inc
+++ b/terminus.user.api.inc
@@ -121,8 +121,10 @@ function terminus_api_user_uuid_get($user_uuid, $email) {
 /**
  * API Call to Check a User's Email by Email
  * NOTE - No logging!
+ *
+ * TODO: Invalid path, fix or remove
  */
-function terminus_api_user_email_check_by_email($email) {
+function terminus_api_user_email_check_by_email($user_uuid, $email) {
   $realm = 'user';
   $uuid = $user_uuid;
   $path = rawurlencode($email) . '/email';
@@ -151,6 +153,7 @@ function terminus_api_user_email_set($user_uuid, $email) {
 function terminus_api_user_delete($user_uuid) {
   $realm = 'user';
   $uuid = $user_uuid;
+  $path = '';
   $method = 'DELETE';
 
   return terminus_request($realm, $uuid, $path, $method);

--- a/terminus.user.api.inc
+++ b/terminus.user.api.inc
@@ -109,10 +109,10 @@ function terminus_api_user_email_get($user_uuid) {
  * API Call to Get a User's UUID
  * NOTE - No logging!
  */
-function terminus_api_user_uuid_get($email) {
+function terminus_api_user_uuid_get($user_uuid, $email) {
   $realm = 'user';
   $uuid = $user_uuid;
-  $path = rawurlencode($email) . '/uuid';
+  $path = 'uuid/' . rawurlencode($email);
   $method = 'GET';
 
   return terminus_request($realm, $uuid, $path, $method);


### PR DESCRIPTION
I fixed the implementation of get_uuid(). The path was setup to `<email>/uuid` but when it didn't work, I figured out it just needed to be swapped to: `uuid/<email>`

Also initialized some un-declared vars before they were used.
