### PR TITLE
defer_permissions option for permission issues with sshfs on osx

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -2635,9 +2635,16 @@ function drush_terminus_pantheon_site_mount($site_uuid = FALSE, $environment = F
   }
   extract($session_data);
 
-  $test = exec('which sshfs', $output, $ret);
+  exec('which sshfs', $output, $ret);
   if ($ret !== 0) {
     return drush_set_error("'sshfs' command not found. Please install from http://osxfuse.github.io/");
+  }
+
+  $darwin = False;
+  $output = array();
+  exec('uname', $output, $ret);
+  if (is_array($output) && isset($output[0]) && strpos($output[0], 'Darwin') !== False) {
+    $darwin = True;
   }
 
   if (!$site_uuid = terminus_site_input($site_uuid)) {
@@ -2673,7 +2680,8 @@ function drush_terminus_pantheon_site_mount($site_uuid = FALSE, $environment = F
 
   $user = $environment . '.' . $site_uuid;
   $host = 'appserver.' . $environment . '.' . $site_uuid . '.drush.in';
-  $cmd = "sshfs -p 2222 {$user}@{$host}:./ {$destination}";
+  $darwin_args = $darwin ? '-o defer_permissions ' : '';
+  $cmd = "sshfs " . $darwin_args . "-p 2222 {$user}@{$host}:./ {$destination}";
 
   drush_shell_exec($cmd);
   $output = drush_shell_exec_output();

--- a/terminus.site.api.inc
+++ b/terminus.site.api.inc
@@ -11,6 +11,7 @@
 function terminus_api_site_info($site_uuid) {
   $realm = 'site';
   $uuid = $site_uuid;
+  $path = '';
   $method = 'GET';
 
   return terminus_request($realm, $uuid, $path, $method);

--- a/terminus.user.api.inc
+++ b/terminus.user.api.inc
@@ -121,8 +121,10 @@ function terminus_api_user_uuid_get($user_uuid, $email) {
 /**
  * API Call to Check a User's Email by Email
  * NOTE - No logging!
+ *
+ * TODO: Invalid path, fix or remove
  */
-function terminus_api_user_email_check_by_email($email) {
+function terminus_api_user_email_check_by_email($user_uuid, $email) {
   $realm = 'user';
   $uuid = $user_uuid;
   $path = rawurlencode($email) . '/email';
@@ -151,6 +153,7 @@ function terminus_api_user_email_set($user_uuid, $email) {
 function terminus_api_user_delete($user_uuid) {
   $realm = 'user';
   $uuid = $user_uuid;
+  $path = '';
   $method = 'DELETE';
 
   return terminus_request($realm, $uuid, $path, $method);

--- a/terminus.user.api.inc
+++ b/terminus.user.api.inc
@@ -109,10 +109,10 @@ function terminus_api_user_email_get($user_uuid) {
  * API Call to Get a User's UUID
  * NOTE - No logging!
  */
-function terminus_api_user_uuid_get($email) {
+function terminus_api_user_uuid_get($user_uuid, $email) {
   $realm = 'user';
   $uuid = $user_uuid;
-  $path = rawurlencode($email) . '/uuid';
+  $path = 'uuid/' . rawurlencode($email);
   $method = 'GET';
 
   return terminus_request($realm, $uuid, $path, $method);


### PR DESCRIPTION
As mentioned as a side note in #42, there are permission issues in OSX. `-o defer_permissions` is an OSX only option and will cause errors on other systems where it is not available.

This verifies if the system is OSX with `uname`, then adds the option if it is.

If you want to test, try reading a php.ini file without the option. Access will be denied because of invalid ownership. Once the file system is mounted with the option, you will be able to read php.ini.
