### PR TITLE
Add compact option to site-uuid.

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -441,6 +441,9 @@ function terminus_drush_command() {
     'examples' => array(
       'drush psite-uuid mysite --nocache' => 'Get the UUID of your site.',
     ),
+    'options' => array(
+      'compact' => 'Output only uuid. Useful for scripting.',
+    ),
     'required-arguments' => TRUE,
     'aliases' => array('psite-uuid'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
@@ -1668,6 +1671,9 @@ function drush_terminus_pantheon_site_uuid() {
   foreach ($site_names as $site_name) {
     if ($site_uuid = terminus_get_site_uuid_by_name($site_name)) {
       $output = $site_name . ': ' . $site_uuid;
+      if (drush_get_option('compact')) {
+        $output = $site_uuid;
+      }
     }
     else {
       $output = dt('@site_name: No uuid found.', array('@site_name' => $site_name));


### PR DESCRIPTION
Hey guys!

Great work on this stuff! 

OK, here goes:

Having psite-uuid outputting only the uuid is super useful for scripting, as pointed out in #133. 

One can always bash hack around, as that issue shows. But adding an option does not break any current functionality and adds the features we all want (scripting abilities).

This patch exposes a --compact option to the command, which outputs only site uuid.

Also, the README uses psite-uuid and expects only the uuid to come back, which is not working (the example). Should be updated to, but waiting for some response on this before I send a pull request for that :)
