### PR TITLE
Update run_tests.sh, phpunit.php moved to phpunit'

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php vendor/phpunit/phpunit/phpunit.php --bootstrap=vendor/drush/drush/tests/drush_testcase.inc tests/
+php vendor/phpunit/phpunit/phpunit --bootstrap=vendor/drush/drush/tests/drush_testcase.inc tests/


### PR DESCRIPTION
run_tests.php is looking for phpunit at vendor/phpunit/phpunit/phpunit.php but it has moved to vendor/phpunit/phpunit/phpunit.
