### PR TITLE
Change the exit code when "no changes found to commit."

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -2692,7 +2692,7 @@ function drush_terminus_pantheon_site_commit_validate($site_uuid = FALSE, $envir
 
   $diffstat = termins_render_diffstat($site_uuid, $environment);
   if (!$diffstat) {
-    return drush_set_error('DRUSH_PSITE_COMMIT_NO_CHANGES', dt('No changes found to commit, aborting.'));
+    return drush_user_abort(dt('No changes found to commit, aborting.'));
   }
 
   $message = drush_get_option('message', FALSE);


### PR DESCRIPTION
I am incorporating Terminus to allow for integration between a CI workflow and my Pantheon environment.

Currently, because of other things involved in the CI workflow, there are a number of builds happening that don't include changes to the Drupal docroot.  In these cases, there are no code changes to the Pantheon environment which triggers the "No changes found to commit" message towards the end of the build process.

Since this message is being returned with `drush_set_error()` it is causing the deployment step to exit with an error code.  This triggers a build failure even though the step is doing exactly what it should do and skipping over the commit process.

I propose changing this to `drush_user_abort()` which will not exit with an error code but will continue to function exactly as it did previously and exit the process immediately once Terminus determines no changes are present.
