### PR TITLE
Fix infinite loop caused by edge case during terminus_job_poll()

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -3794,7 +3794,7 @@ function terminus_request($realm, $uuid, $path = FALSE, $method = 'GET', $data =
     CURLOPT_HEADER => 1,
     CURLOPT_PORT => TERMINUS_PORT,
     CURLOPT_RETURNTRANSFER => 1,
-    CURLOPT_TIMEOUT => 30,
+    CURLOPT_TIMEOUT => 45,
     CURLOPT_CUSTOMREQUEST => $method,
     CURLOPT_COOKIE => $session_data['session'],
     CURLOPT_HTTPHEADER => $headers,

--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -3759,7 +3759,7 @@ function terminus_validate_session($data) {
  */
 function terminus_request($realm, $uuid, $path = FALSE, $method = 'GET', $data = NULL) {
   static $ch = FALSE;
-  if (!$ch) {
+  if (gettype($ch) !== 'resource') {
     $ch = curl_init();
   }
   $headers = array();


### PR DESCRIPTION
## Problem / motivation

In cases where `terminus_request()` errors (e.g. a timeout), it will return `FALSE` and close the curl handle / resource.  Normally, this is fine and doesn't matter...  But when `terminus_request()` is called by `terminus_job_poll()`, it's possible to get stuck in an infinite loop.

Underlying cause is that the curl handle is statically cached in terminus_request...  Although there's a check to re-initialize it, the check isn't explicit enough (specifically, `$ch` will be an integer when closed, which is truthy).
## Proposed resolution

Explicitly check that the curl handle is a resource. Also, increase the timeout to match the server-side timeout (which appears to be 45 seconds).
