### PR TITLE
Check that terminus_jobs_list() returns truthy before iterating

### DIFF
--- a/terminus.drush.inc
+++ b/terminus.drush.inc
@@ -1750,13 +1750,14 @@ function terminus_job_poll($site_uuid, $slot) {
   while (TRUE) {
     echo '.';
     sleep(5);
-    $jobs = terminus_jobs_list($site_uuid, FALSE, $slot);
-    foreach ($jobs as $job) {
-      if ($job['completed']) {
-        if ($job['status'] != 'SUCCESS') {
-          return FALSE;
+    if ($jobs = terminus_jobs_list($site_uuid, FALSE, $slot)) {
+      foreach ($jobs as $job) {
+        if ($job['completed']) {
+          if ($job['status'] != 'SUCCESS') {
+            return FALSE;
+          }
+          return TRUE;
         }
-        return TRUE;
       }
     }
   }


### PR DESCRIPTION
Related to #188, but just a minor annoyance. PHP throws a warning when Terminus is unable to return a job list.

```
Invalid argument supplied for foreach() terminus.drush.inc:1754
```

Just need to account for `terminus_jobs_list()` returning FALSE.
